### PR TITLE
update k8s-install-faqs.md

### DIFF
--- a/src/online/k8s-install-faqs.md
+++ b/src/online/k8s-install-faqs.md
@@ -10,130 +10,127 @@
 
 kubespray 的离线安装文档：<https://github.com/kubernetes-sigs/kubespray/blob/master/docs/operations/offline-environment.md>
 
-## 修改 LVM size
+## 调整 LVM 的逻辑卷大小
 
-在准备节点的过程中，有时需要调整 LVM size。
+Logical Volume Manager（LVM）是 Linux 环境下对磁盘分区进行管理的一种机制。
 
-参考：<https://www.redhat.com/sysadmin/resize-lvm-simple>
+LVM的主要概念有：
+
+1. PV (Physical Volume)：物理卷，可以是整个物理硬盘或实际物理硬盘上的分区。
+2. VG (Volume Group)：卷组，将数个PV进行整合，形成一个存储池。
+3. LV (Logical Volume)：逻辑卷，由VG划分而来，LV的大小与PE的大小及PE的数量有关。
+4. PE (Physical Extent)：物理区块，他是LVM中的最小存储单元。
+
+在准备节点的过程中，有时需要调整逻辑卷的大小，下面介绍具体的操作方式。
+
+参考：
+
+1. <a target="_blank" rel="noopener noreferrer" href="https://linux.die.net/man/8/lvextend">lvextend(8) - Linux man page</a>
+2. <a target="_blank" rel="noopener noreferrer" href="https://www.redhat.com/sysadmin/resize-lvm-simple">How to resize a logical volume with 5 simple LVM commands</a>
+
+
+查看文件系统和磁盘信息：
 
 ```bash
-root@nc06:/home/t9k# lsblk
-NAME                      MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
-loop0                       7:0    0  63.5M  1 loop /snap/core20/1950
-loop1                       7:1    0  91.9M  1 loop /snap/lxd/24061
-loop2                       7:2    0  49.9M  1 loop 
-loop3                       7:3    0  67.8M  1 loop /snap/lxd/22753
-loop4                       7:4    0  63.3M  1 loop 
-loop5                       7:5    0  53.3M  1 loop /snap/snapd/19457
-loop6                       7:6    0  53.3M  1 loop /snap/snapd/19361
-loop7                       7:7    0  63.5M  1 loop /snap/core20/1974
-nvme0n1                   259:0    0 465.8G  0 disk 
-├─nvme0n1p1               259:1    0   1.1G  0 part /boot/efi
-├─nvme0n1p2               259:2    0     2G  0 part /boot
-└─nvme0n1p3               259:3    0 462.7G  0 part 
-  └─ubuntu--vg-ubuntu--lv 253:0    0 462.7G  0 lvm  /
+lsblk
 ```
 
 ```bash
-root@nc06:/home/t9k# df -hl
+NAME                      MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
+loop0                       7:0    0  63.9M  1 loop /snap/core20/2318
+loop1                       7:1    0  63.9M  1 loop /snap/core20/2105
+loop3                       7:3    0    87M  1 loop /snap/lxd/28373
+loop4                       7:4    0  38.7M  1 loop /snap/snapd/21465
+loop5                       7:5    0  38.8M  1 loop /snap/snapd/21759
+loop6                       7:6    0    87M  1 loop /snap/lxd/29351
+sda                         8:0    0 447.1G  0 disk 
+├─sda1                      8:1    0     1G  0 part /boot/efi
+├─sda2                      8:2    0     2G  0 part /boot
+└─sda3                      8:3    0 444.1G  0 part 
+  └─ubuntu--vg-ubuntu--lv 252:0    0   440G  0 lvm  /var/lib/containers/storage/overlay
+                                                    /
+```
+
+查看文件系统的信息：
+
+```bash
+df -hl
+```
+
+```bash
 Filesystem                         Size  Used Avail Use% Mounted on
-udev                                16G     0   16G   0% /dev
-tmpfs                              3.2G   16M  3.1G   1% /run
-/dev/mapper/ubuntu--vg-ubuntu--lv   98G   63G   30G  68% /
-tmpfs                               16G     0   16G   0% /dev/shm
+tmpfs                              1.6G   31M  1.5G   2% /run
+efivarfs                           192K  108K   80K  58% /sys/firmware/efi/efivars
+/dev/mapper/ubuntu--vg-ubuntu--lv  433G   18G  393G   5% /
+tmpfs                              7.7G     0  7.7G   0% /dev/shm
 tmpfs                              5.0M     0  5.0M   0% /run/lock
-tmpfs                               16G     0   16G   0% /sys/fs/cgroup
-/dev/nvme0n1p2                     2.0G  109M  1.7G   6% /boot
-/dev/nvme0n1p1                     1.1G  6.1M  1.1G   1% /boot/efi
-/dev/loop1                          92M   92M     0 100% /snap/lxd/24061
-/dev/loop3                          68M   68M     0 100% /snap/lxd/22753
+/dev/sda2                          2.0G  417M  1.4G  23% /boot
+/dev/sda1                          1.1G  6.1M  1.1G   1% /boot/efi
+tmpfs                              1.6G  4.0K  1.6G   1% /run/user/1000
 ```
 
-Identify the Logical Volume：
+查看卷组的信息：
 
 ```bash
-root@nc06:/home/t9k# lvs
+vgs # 如需更详细的信息，可以运行 vgdisplay
+```
+
+```bash
+  VG        #PV #LV #SN Attr   VSize    VFree 
+  ubuntu-vg   1   1   0 wz--n- <444.08g <4.08g
+```
+
+查看逻辑卷的信息：
+
+```bash
+lvs # 如需更详细的信息，可以运行 lvdisplay
+```
+
+```bash
   LV        VG        Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
-  ubuntu-lv ubuntu-vg -wi-ao---- 100.00g 
+  ubuntu-lv ubuntu-vg -wi-ao---- 440.00g 
 ```
 
-Extend the Logical Volume，这里除了使用 `-l +100%FREE` 指定百分比以外，也可以使用 `-L +50G` 的方式指定具体的大小：
+扩展逻辑卷，将它增加 2GB，并同时调整文件系统的大小：
 
 ```bash
-root@nc06:/home/t9k# lvextend -l +100%FREE /dev/ubuntu-vg/ubuntu-lv 
-  Size of logical volume ubuntu-vg/ubuntu-lv changed from 100.00 GiB (25600 extents) to <462.71 GiB (118453 extents).
+lvextend --resizefs --size +2GB /dev/ubuntu-vg/ubuntu-lv
+```
+
+```bash
+  Size of logical volume ubuntu-vg/ubuntu-lv changed from 440.00 GiB (112640 extents) to 442.00 GiB (113152 extents).
   Logical volume ubuntu-vg/ubuntu-lv successfully resized.
-```
-
-验证：
-
-```bash
-root@nc06:/home/t9k# lsblk
-NAME                      MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
-loop0                       7:0    0  63.5M  1 loop /snap/core20/1950
-loop1                       7:1    0  91.9M  1 loop /snap/lxd/24061
-loop2                       7:2    0  49.9M  1 loop 
-loop3                       7:3    0  67.8M  1 loop /snap/lxd/22753
-loop4                       7:4    0  63.3M  1 loop 
-loop5                       7:5    0  53.3M  1 loop /snap/snapd/19457
-loop6                       7:6    0  53.3M  1 loop /snap/snapd/19361
-loop7                       7:7    0  63.5M  1 loop /snap/core20/1974
-nvme0n1                   259:0    0 465.8G  0 disk 
-├─nvme0n1p1               259:1    0   1.1G  0 part /boot/efi
-├─nvme0n1p2               259:2    0     2G  0 part /boot
-└─nvme0n1p3               259:3    0 462.7G  0 part 
-  └─ubuntu--vg-ubuntu--lv 253:0    0 462.7G  0 lvm  /
-```
-
-但是文件系统不会自动扩大：
-
-```bash
-root@nc06:/home/t9k# df -hl
-Filesystem                         Size  Used Avail Use% Mounted on
-udev                                16G     0   16G   0% /dev
-tmpfs                              3.2G   16M  3.1G   1% /run
-/dev/mapper/ubuntu--vg-ubuntu--lv   98G   63G   30G  68% /
-tmpfs                               16G     0   16G   0% /dev/shm
-tmpfs                              5.0M     0  5.0M   0% /run/lock
-tmpfs                               16G     0   16G   0% /sys/fs/cgroup
-/dev/nvme0n1p2                     2.0G  109M  1.7G   6% /boot
-/dev/nvme0n1p1                     1.1G  6.1M  1.1G   1% /boot/efi
-/dev/loop1                          92M   92M     0 100% /snap/lxd/24061
-/dev/loop3                          68M   68M     0 100% /snap/lxd/22753
+resize2fs 1.46.5 (30-Dec-2021)
+Filesystem at /dev/mapper/ubuntu--vg-ubuntu--lv is mounted on /; on-line resizing required
+old_desc_blocks = 55, new_desc_blocks = 56
+The filesystem on /dev/mapper/ubuntu--vg-ubuntu--lv is now 115867648 (4k) blocks long.
 ```
 
 <aside class="note">
 <div class="title">注意</div>
 
-`resize2fs` 是针对 ext2, ext3, ext4 文件系统调整大小的命令，如果使用其他文件系统，请查找对应的命令。
+1. `--resizefs` 参数仅适用于 ext2, ext3, ext4, ReiserFS, XFS 文件系统。
+2. 除了使用 `--size +2GB` 指定具体的大小外，也可以使用 `-l +100%FREE` 指定百分比。
 
 </aside>
 
-Extend the filesystem，在调整文件系统大小之前，应确保文件系统已备份，并且没有错误：
+
+验证文件系统已经扩大：
 
 ```bash
-root@nc06:/home/t9k# resize2fs /dev/mapper/ubuntu--vg-ubuntu--lv
-resize2fs 1.45.5 (07-Jan-2020)
-Filesystem at /dev/mapper/ubuntu--vg-ubuntu--lv is mounted on /; on-line resizing required
-old_desc_blocks = 13, new_desc_blocks = 58
-The filesystem on /dev/mapper/ubuntu--vg-ubuntu--lv is now 121295872 (4k) blocks long.
+df -hl
 ```
 
-验证：
-
 ```bash
-root@nc06:/home/t9k# df -hl
 Filesystem                         Size  Used Avail Use% Mounted on
-udev                                16G     0   16G   0% /dev
-tmpfs                              3.2G   16M  3.1G   1% /run
-/dev/mapper/ubuntu--vg-ubuntu--lv  455G   63G  373G  15% /
-tmpfs                               16G     0   16G   0% /dev/shm
+tmpfs                              1.6G   31M  1.5G   2% /run
+efivarfs                           192K  108K   80K  58% /sys/firmware/efi/efivars
+/dev/mapper/ubuntu--vg-ubuntu--lv  434G   18G  394G   5% /
+tmpfs                              7.7G     0  7.7G   0% /dev/shm
 tmpfs                              5.0M     0  5.0M   0% /run/lock
-tmpfs                               16G     0   16G   0% /sys/fs/cgroup
-/dev/nvme0n1p2                     2.0G  109M  1.7G   6% /boot
-/dev/nvme0n1p1                     1.1G  6.1M  1.1G   1% /boot/efi
-/dev/loop1                          92M   92M     0 100% /snap/lxd/24061
-/dev/loop3                          68M   68M     0 100% /snap/lxd/22753
+/dev/sda2                          2.0G  417M  1.4G  23% /boot
+/dev/sda1                          1.1G  6.1M  1.1G   1% /boot/efi
+tmpfs                              1.6G  4.0K  1.6G   1% /run/user/1000
 ```
 
 ## 日志收集不完整


### PR DESCRIPTION
原文档中的"调整 LVM 的逻辑卷大小"部分使用了较为麻烦的“先扩展逻辑卷，然后扩展文件系统”的两个命令。

修改为使用一个命令来完成这两个步骤。