### PR TITLE
add installation about t9k-auditing-log

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -38,6 +38,7 @@
         * [沐曦 MetaX](hardware/metax/index.md)
     * [安装 TensorStack AI 计算平台](online/products/index.md)
         * [安装前准备](online/products/pre-install.md)
+            * [配置 T9k Monitoring](online/products/pre-install/t9k-monitoring.md)
         * [安装产品-User Console 模式](online/products/install-uc-mode.md)
             * [安装产品](online/products/install-uc.md)
             * [注册 APP](online/products/register-app.md)

--- a/src/appendix/cluster-admin-installation-configuration.md
+++ b/src/appendix/cluster-admin-installation-configuration.md
@@ -57,9 +57,12 @@
 7. AutotuneExperiment：依赖 AutotuneExperiment 的集群管理组件有
     1. Cluster Admin Web
         1. 工作负载->资源状态->AutotuneExperiment
-8. 集群预先安装 elasticserach：
+8. 集群预先安装 elasticserach：依赖 elasticserach 的集群管理组件有
     1. Cluster Admin Web
         1. 监控与报警->其他工具->Kibana
+9. T9k 审计日志：依赖 T9k 审计日志的集群管理组件有
+    1. Cluster Admin Web
+        1. 审计日志
 
 ## Values.yaml
 
@@ -76,9 +79,10 @@ Duration Keeper 组件相关的参数：
 1. options.durationKeeper：值类型 bool。设为 false 时，系统不会安装 Duration Keeper
 
 控制 Cluster Admin Web 是否显示 UI 组件的参数：
-1. 参数的键是 global.t9k.clusterAdminWeb.uiComponentDisplay.<ui-component-name>
+1. 参数的键是 `global.t9k.clusterAdminWeb.uiComponentDisplay.<ui-component-name>`
 2. 值类型是 bool，表明是否显示这个 UI 组件
-3. <ui-component-name> 及其对应的 ui 组件如下：
+3. `<ui-component-name>` 及其对应的 ui 组件如下：
+    1. auditing: 审计日志
     1. overviewWorkloadT9kJobs: 总览->工作负载章节->展示 Job 数量
     2. t9kSchedulerWorkloadListFilterButton: 所有页面->工作负载列表->队列/PodGroup 筛选按钮
     3. resourceManagementT9kScheduler: 资源管理->调度

--- a/src/online/products/pre-install/t9k-monitoring.md
+++ b/src/online/products/pre-install/t9k-monitoring.md
@@ -1,0 +1,63 @@
+# 配置 T9k Monitoring
+
+在安装产品模块 T9k Monitoring 之前，请根据你所需要的功能来配置 K8s 集群和 T9k 产品。
+
+## T9k 审计日志
+
+T9k 审计日志分为下列两种类型：
+1. 平台管理：记录 T9k 管理员的操作行为，例如创建用户、修改资源价格。
+2. 资源对象：记录系统级别 namespace 中的资源对象发生的变化、cluster-wide 资源对象发生的变化，例如管理员在集群中创建了新的 CRD workflowtemplates.argoproj.io。
+
+### 启用 T9k 审计日志
+
+如果你想启用 T9k 审计日志，请确保进行了下列配置。
+
+#### 设置 Kubernetes 审计
+
+安装 K8s 集群时，按照[设置 Kubernetes 审计](../../k8s-install.md#设置-kubernetes-审计)对集群进行配置。
+
+#### 配置 loki
+
+安装 loki 时，按照[Values 配置->T9k 审计日志](../../k8s-components/loki.md#t9k-审计日志) 对 promtail 进行配置。
+
+#### values.yaml
+
+确保 t9k-monitoring 使用的 values.yaml 设置了下列字段：
+
+```yaml
+options:
+  t9kUseralertOperator:
+    enabled: true
+```
+
+### 禁用 T9k 审计日志
+
+如果你想禁用 T9k 审计日志，请参考下列设置。
+
+#### [可选]设置 Kubernetes 审计
+
+推荐你在安装 K8s 集群时，将 [k8s-cluster.yml](../../k8s-install.md#k8s-clusteryml) 的 `kubernetes_audit` 字段设为 false，禁用 Kubernetes 审计以节省计算资源。
+
+#### [可选]配置 loki
+
+推荐你在安装 loki 时，删除[Values 配置->T9k 审计日志](../../k8s-components/loki.md#t9k-审计日志) 中收集 K8s 审计日志的配置内容。
+
+#### values.yaml
+
+##### t9k-monitoring
+
+确保产品模块 t9k-monitoring 使用的 values.yaml 设置了下列字段：
+
+```yaml
+options:
+  t9kUseralertOperator:
+    enabled: false
+```
+
+##### t9k-security-console-api
+
+确保产品模块 t9k-security-console-api 使用的 values.yaml 中字段 `global.t9k.securityService.resourceManagement.proxyoperation.enabled` 的值是 false。
+
+##### t9k-cost
+
+确保产品模块 t9k-cost 使用的 values.yaml 中字段 `global.t9k.cost.proxyoperation.enabled` 的值是 false。


### PR DESCRIPTION
修改文档说明如何安装配置 `T9k 审计日志`，主要进行了下列修改：
1. `1.3.1 基本安装` 增加章节 `配置 -> 设置 Kubernetes 审计`
2. `1.4.5 Loki` 增加章节 `安装 -> Values 配置 -> T9k 审计日志`
3. 增加目录`1.6.1.1 配置 T9k Monitoring`
4. `4.14 集群管理安装配置` 增加审计日志的 UI 参数说明